### PR TITLE
Update publications.html

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -205,7 +205,7 @@
               <h4 class="card-title">
                 <a href="https://www.sciencedirect.com/science/article/pii/S001046551830256X" target="_blank">Linear solver: AAR II</a>
               </h4>
-             <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software">Open Source Software &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<a href="https://data.mendeley.com/datasets/669xrdcwry/1" target="_blank">link</a></div>
+             <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software"><a href="https://data.mendeley.com/datasets/669xrdcwry/1" target="_blank">Open Source Software </a></div>
 
 		    <p class="card-text">Alternating Anderson–Richardson method: An efficient alternative to preconditioned Krylov methods for large, sparse linear systems</p>
 		<div class="mt-auto">
@@ -307,7 +307,7 @@
               <h4 class="card-title">
                 <a href="https://www.sciencedirect.com/science/article/pii/S0010465517304022" target="_blank">Kohn-Sham DFT: SQDFT</a>
               </h4>
-              <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software">Open Source Software &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<a href="https://data.mendeley.com/datasets/h4jnrmh9v3/1" target="_blank">link</a></div>
+              <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software"><a href="https://data.mendeley.com/datasets/h4jnrmh9v3/1" target="_blank">Open Source Software</a></div>
 
 		    <p class="card-text">SQDFT: Spectral Quadrature method for large-scale parallel O(N) Kohn–Sham calculations at high temperature</p>
 		<div class="mt-auto">
@@ -350,7 +350,7 @@
               <h4 class="card-title">
                 <a href="https://www.sciencedirect.com/science/article/pii/S0010465517300711" target="_blank">Kohn-Sham DFT: SPARC II</a>
               </h4>
-               <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software">Open Source Software &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<a href="http://cpc.cs.qub.ac.uk/summaries/AFBR_v1_0.html" target="_blank">link</a></div>
+               <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software"> <a href="http://cpc.cs.qub.ac.uk/summaries/AFBR_v1_0.html" target="_blank">Open Source Software</a></div>
 
 		    <p class="card-text">SPARC: Accurate and efficient finite-difference formulation and parallel implementation of Density Functional Theory: Extended systems</p>
 		<div class="mt-auto">
@@ -386,7 +386,7 @@
               <h4 class="card-title">
                 <a href="https://www.sciencedirect.com/science/article/pii/S0010465516303046" target="_blank">Kohn-Sham DFT: SPARC I</a>
               </h4>
-               <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software">Open Source Software &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<a href="http://cpc.cs.qub.ac.uk/summaries/AFBL_v1_0.html" target="_blank">link</a></div>
+               <div class="deployed" data-toggle="tooltip" data-placement="top" title="Open Source Software"><a href="http://cpc.cs.qub.ac.uk/summaries/AFBL_v1_0.html" target="_blank">Open Source Software</a></div>
 
 		    <p class="card-text">SPARC: Accurate and efficient finite-difference formulation and parallel implementation of Density Functional Theory: Isolated clusters</p>
 		<div class="mt-auto">
@@ -527,7 +527,7 @@
               </h4>
               <p class="card-text">Ab initio strain engineering of graphene: opening bandgaps up to 1 eV	</p>
 		<div class="mt-auto">
-		<i >  	RSC Adv. (Communication) (2015)</i>
+		<i >  	RSC Adv., Communication, (2015)</i>
 		</div>
 		
             </div>
@@ -698,7 +698,7 @@
             </h4>
             <p class="card-text">Design of Miura-Ori Patterns With Acoustic Bandgaps</p>
 		<div class="mt-auto">
-		<i >  	(2017) </i>
+		<i >  	IDETC/CIE (2017) </i>
 		</div>		  
           </div>
         </div>
@@ -713,7 +713,7 @@
             </h4>
             <p class="card-text">Domain Switching Criteria for Tetragonal Phase Ferroelectrics: A Comparative Study</p>
 		<div class="mt-auto">
-		<i >  	(2006) </i>
+		<i > ICCM04 (2006) </i>
 		</div>	
           </div>
         </div>
@@ -728,7 +728,7 @@
             </h4>
             <p class="card-text">Switch toughening of ferroelectrics</p>
 		<div class="mt-auto">
-		<i >  	(2005) </i>
+		<i >  ICSMS (2005) </i>
 		</div>
           </div>
         </div>


### PR DESCRIPTION
Changed the following:

1) RSC Adv. (Communication) (2015) ---> RSC Adv., Communication, (2015)
2) Link the open source software to the software pages, no need to have separate "link" in each
3) Origami: Acoustic bandgap: Put IDETC/CIE (2017)
4) Ferroelectrics: Domain switching criteria II: ICCM04 (2006)
5) Ferroelectrics: Switch toughening: ICSMS (2005)